### PR TITLE
Add simple info view

### DIFF
--- a/lib/hard_data.dart
+++ b/lib/hard_data.dart
@@ -52,6 +52,7 @@ final List<ReusableCard> icu = [
   ),
   ReusableCard(
     title: 'Tips for Junior Staffers',
+    description: '',
     color: Color.fromRGBO(143, 217, 255, 1),
   ),
 ];

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:wh_covid19/view/home_page.dart';
+import 'package:wh_covid19/view/info_view.dart';
 import 'package:wh_covid19/view/ppe/ppe_view.dart';
 import 'package:wh_covid19/view/sbs_guide_view.dart';
 import 'package:wh_covid19/view/staff_welfare/staff_welfare_view.dart';
@@ -22,6 +23,7 @@ class MyApp extends StatelessWidget {
         '/ppe': (context) => PPEView(),
         '/staff_welfare': (context) => StaffWelfareView(),
         '/sbs_guidance': (context) => SBSGuideView(),
+        '/info': (context) => InfoView(),
       },
     );
   }

--- a/lib/view/home_page.dart
+++ b/lib/view/home_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:wh_covid19/hard_data.dart';
 import 'package:wh_covid19/style.dart';
+import 'package:wh_covid19/view/info_view.dart';
 import 'package:wh_covid19/widget/card_container.dart';
 
 class HomePage extends StatelessWidget {
@@ -25,7 +26,7 @@ class HomePage extends StatelessWidget {
                     ),
                     IconButton(
                       icon: Icon(Icons.info_outline),
-                      onPressed: () {},
+                      onPressed: () => InfoView.navigateTo(context),
                     )
                   ],
                 ),

--- a/lib/view/info_view.dart
+++ b/lib/view/info_view.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:package_info/package_info.dart';
+import 'package:wh_covid19/style.dart';
+import 'package:wh_covid19/widget/reusable_card.dart';
+
+class InfoView extends StatelessWidget {
+  final title = 'Information';
+  static final _cardHeight = 34.0;
+  static final _cardColor = Colors.white;
+  static final routeName = '/info';
+
+  static void navigateTo(BuildContext context) {
+    Navigator.pushNamed(context, routeName);
+  }
+
+  final topCards = <Widget>[
+    ReusableCard(
+      title: 'Contact Numbers',
+      color: _cardColor,
+      height: _cardHeight,
+    ),
+    ReusableCard(
+      title: 'Society & College Recommendations',
+      color: _cardColor,
+      height: _cardHeight,
+    )
+  ];
+
+  final bottomCards = <Widget>[
+    ReusableCard(
+      title: 'App Feedback',
+      color: _cardColor,
+      height: _cardHeight,
+    ),
+    ReusableCard(
+      title: 'Disclaimer & Conditions of Use',
+      color: _cardColor,
+      height: _cardHeight,
+    )
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: appBarColor,
+        iconTheme: appBarIconTheme,
+        title: Text(
+          title,
+          style: appBarTextStyle,
+        ),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: ListView(
+          children: <Widget>[
+            _buildSpacer(),
+            ...topCards,
+            _buildSpacer(),
+            ..._buildAbout(),
+            _buildSpacer(),
+            ...bottomCards,
+            _buildSpacer(),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSpacer({double height = 32}) => Container(height: height);
+
+  List<Widget> _buildAbout() {
+    return [
+      Image.asset(
+        'assets/images/icon/high_res_icon.png',
+        height: 84,
+        width: 84,
+      ),
+      Center(child: _buildVersionTextWidget()),
+      _buildSpacer(),
+      Text(
+          'About this app. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Purus gravida quis blandit turpis cursus in hac habitasse platea. In vitae turpis massa sed elementum tempus. Pulvinar neque laoreet suspendisse interdum consectetur libero.'),
+    ];
+  }
+
+  Widget _buildVersionTextWidget() {
+    return FutureBuilder<PackageInfo>(
+      future: PackageInfo.fromPlatform(),
+      initialData: null,
+      builder: (context, snapshot) {
+        var text = '';
+        if (snapshot.hasData) {
+          final packageInfo = snapshot.data;
+          text = 'v${packageInfo.version} (${packageInfo.buildNumber})';
+        }
+        return Text(text);
+      },
+    );
+  }
+}

--- a/lib/widget/reusable_card.dart
+++ b/lib/widget/reusable_card.dart
@@ -14,8 +14,11 @@ class ReusableCard extends StatelessWidget {
   /// Route to view
   final String routeTo;
 
-  ReusableCard(
-      {@required this.title, this.description, this.color = Colors.white, this.routeTo})
+  /// Height of card
+  final double height;
+
+  ReusableCard({@required this.title, this.description, this.color = Colors
+      .white, this.routeTo, this.height = 84})
       : assert(title != null);
 
   @override
@@ -29,23 +32,27 @@ class ReusableCard extends StatelessWidget {
             borderRadius: BorderRadius.all(Radius.circular(8))),
         child: Padding(
           padding: const EdgeInsets.all(12),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            mainAxisSize: MainAxisSize.min,
-            children: <Widget>[
-              Text(
-                title,
-                style: cardTitleTextStyle,
-              ),
-              SizedBox(
-                height: 50,
-              ),
-              description != null ? Text(
-                description,
-                style: cardDescriptionTextStyle,
-              ) : Container(),
-            ],
+          child: Container(
+            height: height,
+            child: Column(
+              mainAxisAlignment: description == null
+                  ? MainAxisAlignment.center
+                  : MainAxisAlignment.spaceBetween,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                Text(
+                  title,
+                  style: cardTitleTextStyle,
+                ),
+                if (description != null)
+                  Spacer(),
+                description != null ? Text(
+                  description,
+                  style: cardDescriptionTextStyle,
+                ) : Container(),
+              ],
+            ),
           ),
         ),
       ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -88,6 +88,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.8"
+  package_info:
+    dependency: "direct main"
+    description:
+      name: package_info
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.4.0+16"
   path:
     dependency: transitive
     description:
@@ -186,3 +193,4 @@ packages:
     version: "3.5.0"
 sdks:
   dart: ">=2.4.0 <3.0.0"
+  flutter: ">=1.10.0 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,11 +4,12 @@ description: A new Flutter project.
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.3.0 <3.0.0"
 
 dependencies:
   flutter:
     sdk: flutter
+  package_info: ^0.4.0+16
 
 dev_dependencies:
   flutter_test:
@@ -24,6 +25,7 @@ flutter:
 
   assets:
     - assets/images/
+    - assets/images/icon/
 
   fonts:
     - family: Inter


### PR DESCRIPTION
Add the simple info view screen (when you click the little "info" button on the home screen)

## Changes

Adds new screen. Modifies reusable_card. See below for other notes from changes.

## Screenshots

<img width="424" alt="Screen Shot 2020-03-22 at 11 46 48 pm" src="https://user-images.githubusercontent.com/869261/77249999-05b89380-6c99-11ea-8462-c54186572739.png">

## Things to note
 - adds dep on package_info package
 - bumps Dart version to min 2.3.0 (to allow for some newer features like spread)
 - adjusts reusable_card to support a single row type mode (when description is null), it also removes the sizedbox in the middle in favor of setting the height of the overall card (found some inconsistent height with cards that had title wrap over otherwise)
