### PR TITLE
setup android release signing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ lib/generated_plugin_registrant.dart
 
 # Exceptions to above rules.
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
+
+android/key.properties

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -51,6 +51,7 @@ android {
     }
 
     signingConfigs {
+         // To sign a release build, you need a android/key.properties file with the keyAlias, keyPassword storeFile and storePassword specified.  Release build signing happens on our CI, so you shouldn't need to do it.
        release {
            keyAlias keystoreProperties['keyAlias']
            keyPassword keystoreProperties['keyPassword']

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -25,6 +25,12 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
+def keystoreProperties = new Properties()
+   def keystorePropertiesFile = rootProject.file('key.properties')
+   if (keystorePropertiesFile.exists()) {
+       keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+   }
+
 android {
     compileSdkVersion 28
 
@@ -37,7 +43,6 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "org.whegba.wh_covid19"
         minSdkVersion 16
         targetSdkVersion 28
@@ -45,11 +50,18 @@ android {
         versionName flutterVersionName
     }
 
+    signingConfigs {
+       release {
+           keyAlias keystoreProperties['keyAlias']
+           keyPassword keystoreProperties['keyPassword']
+           storeFile keystoreProperties['storeFile'] ? file(keystoreProperties['storeFile']) : null
+           storePassword keystoreProperties['storePassword']
+       }
+    }
+
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig signingConfigs.debug
+            signingConfig signingConfigs.release
         }
     }
 }


### PR DESCRIPTION
This is to sign release builds on Codemagic CI master workflow. The matching keystore file and credentials are stored in the CI config within Codemagic.