### PR TITLE
Add new color palette from #9

### DIFF
--- a/lib/hard_data.dart
+++ b/lib/hard_data.dart
@@ -1,6 +1,7 @@
 // A list of two cards
 import 'package:flutter/material.dart';
 import 'package:wh_covid19/routes.dart';
+import 'package:wh_covid19/style.dart';
 
 import 'widget/reusable_card.dart';
 
@@ -25,17 +26,17 @@ final List<ReusableCard> intubation = [
   ReusableCard(
     title: 'Step By Step Guidance',
     description: '12 steps',
-    color: Color.fromRGBO(146, 211, 183, 1),
+    color: AppColors.backgroundGreen,
   ),
   ReusableCard(
     title: 'Checklist',
     description: '12 steps',
-    color: Color.fromRGBO(146, 211, 183, 1),
+    color: AppColors.backgroundGreen,
   ),
   ReusableCard(
     title: 'Algorithm',
     description: '12 steps',
-    color: Color.fromRGBO(146, 211, 183, 1),
+    color: AppColors.backgroundGreen,
   )
 ];
 
@@ -44,17 +45,17 @@ final List<ReusableCard> icu = [
   ReusableCard(
     title: 'Ventilation',
     description: 'Description',
-    color: Color.fromRGBO(143, 217, 255, 1),
+    color: AppColors.backgroundBlue,
   ),
   ReusableCard(
     title: 'General Care',
     description: '',
-    color: Color.fromRGBO(143, 217, 255, 1),
+    color: AppColors.backgroundBlue,
   ),
   ReusableCard(
     title: 'Tips for Junior Staffers',
     description: '',
-    color: Color.fromRGBO(143, 217, 255, 1),
+    color: AppColors.backgroundBlue,
   ),
 ];
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,7 +16,7 @@ class MyApp extends StatelessWidget {
       title: 'EGBA',
       theme: ThemeData(
         primaryColor: Colors.green,
-        backgroundColor: appBackground,
+        backgroundColor: AppColors.appBackground,
         fontFamily: 'Inter',
       ),
       initialRoute: Routes.home,

--- a/lib/style.dart
+++ b/lib/style.dart
@@ -1,34 +1,76 @@
 import 'package:flutter/material.dart';
 
+abstract class AppColors {
+  // Named colors
+  static final Color appBackground = grey500;
+  static final Color backgroundGreen = green500;
+  static final Color backgroundBlue = blue500;
+  static final Color backgroundPurple = purple500;
+
+  // TODO: should come from color palette
+  static final Color backgroundBrown = Color(0xffd3ca92);
+  static final Color majorText = blackAlpha900;
+  static final Color minorText = blackAlpha600;
+
+  // TODO: should come from color palette
+  static final Color appBarIcon = Color.fromRGBO(0, 122, 255, 1.0);
+
+  // TODO: should come from color palette
+  static final Color appBarBackground = Color(0xf0f9f9f9);
+
+  // Color palette
+  static Color green50 = const Color.fromRGBO(214, 233, 191, 1.0);
+  static Color green500 = const Color.fromRGBO(173, 211, 127, 1.0);
+  static Color green600 = const Color.fromRGBO(145, 184, 112, 1.0);
+  static Color green800 = const Color.fromRGBO(75, 117, 74, 1.0);
+  static Color green900 = const Color.fromRGBO(34, 77, 52, 1.0);
+  static Color blue50 = const Color.fromRGBO(181, 226, 239, 1.0);
+  static Color blue500 = const Color.fromRGBO(106, 197, 222, 1.0);
+  static Color blue600 = const Color.fromRGBO(95, 168, 196, 1.0);
+  static Color blue800 = const Color.fromRGBO(68, 94, 131, 1.0);
+  static Color blue900 = const Color.fromRGBO(52, 50, 92, 1.0);
+  static Color purple50 = const Color.fromRGBO(197, 168, 200, 1.0);
+  static Color purple500 = const Color.fromRGBO(139, 81, 144, 1.0);
+  static Color purple600 = const Color.fromRGBO(120, 72, 127, 1.0);
+  static Color purple800 = const Color.fromRGBO(74, 50, 86, 1.0);
+  static Color purple900 = const Color.fromRGBO(46, 37, 61, 1.0);
+  static Color grey50 = const Color.fromRGBO(255, 255, 255, 1.0);
+  static Color grey500 = const Color.fromRGBO(236, 243, 240, 1.0);
+  static Color grey600 = const Color.fromRGBO(175, 185, 181, 1.0);
+  static Color grey800 = const Color.fromRGBO(49, 52, 51, 1.0);
+  static Color grey900 = const Color.fromRGBO(19, 20, 20, 1.0);
+  static Color blackAlpha50 = const Color.fromRGBO(0, 0, 0, 0.2);
+  static Color blackAlpha500 = const Color.fromRGBO(0, 0, 0, 0.4);
+  static Color blackAlpha600 = const Color.fromRGBO(0, 0, 0, 0.6);
+  static Color blackAlpha800 = const Color.fromRGBO(0, 0, 0, 0.8);
+  static Color blackAlpha900 = const Color.fromRGBO(0, 0, 0, 1.0);
+}
+
 // App bar style
-const Color appBarColor = Color(0xf0f9f9f9);
-const TextStyle appBarTextStyle = TextStyle(color: Colors.black, fontSize: 32);
-const IconThemeData appBarIconTheme = IconThemeData(color: Colors.black);
-
-// Colors
-const Color appBackground = Color(0xffecf3f0);
-const Color backgroundGreen = Color(0xff92d3b7);
-const Color backgroundBlue = Color(0xff8fd9ff);
-const Color backgroundBrown = Color(0xffd3ca92);
-
-// Scaffold bg style
+final TextStyle appBarTextStyle = TextStyle(
+  color: AppColors.majorText,
+  fontSize: 32,
+);
+final IconThemeData appBarIconTheme =
+    IconThemeData(color: AppColors.appBarIcon);
 
 // Card Container style
-const TextStyle cardContainerTextStyle = TextStyle(fontSize: 22);
+final TextStyle cardContainerTextStyle = TextStyle(
+  fontSize: 22,
+  color: AppColors.majorText,
+);
 
 // Card styles
-const TextStyle cardTitleTextStyle = TextStyle(
-  color: Color(0xff000000),
-  fontWeight: FontWeight.w600,
-  fontStyle: FontStyle.normal,
-  fontSize: 17.0,
-  fontFamily: 'SFProText'
-);
+final TextStyle cardTitleTextStyle = TextStyle(
+    color: AppColors.majorText,
+    fontWeight: FontWeight.w600,
+    fontStyle: FontStyle.normal,
+    fontSize: 17.0,
+    fontFamily: 'SFProText');
 
-const TextStyle cardDescriptionTextStyle = TextStyle(
-  color: Color(0x993c3c43),
-  fontWeight: FontWeight.w500,
-  fontStyle: FontStyle.normal,
-  fontSize: 12.0,
-  fontFamily: 'SFProText'
-);
+final TextStyle cardDescriptionTextStyle = TextStyle(
+    color: AppColors.minorText,
+    fontWeight: FontWeight.w500,
+    fontStyle: FontStyle.normal,
+    fontSize: 12.0,
+    fontFamily: 'SFProText');

--- a/lib/view/home_page.dart
+++ b/lib/view/home_page.dart
@@ -8,6 +8,7 @@ class HomePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      backgroundColor: AppColors.appBackground,
       body: CustomScrollView(
         slivers: <Widget>[
           SliverAppBar(
@@ -25,14 +26,17 @@ class HomePage extends StatelessWidget {
                       style: appBarTextStyle,
                     ),
                     IconButton(
-                      icon: Icon(Icons.info_outline),
+                      icon: Icon(
+                        Icons.info_outline,
+                        color: AppColors.appBarIcon,
+                      ),
                       onPressed: () => InfoView.navigateTo(context),
                     )
                   ],
                 ),
               ),
             ),
-            backgroundColor: appBarColor,
+            backgroundColor: AppColors.appBarBackground,
             iconTheme: appBarIconTheme,
             floating: true,
             pinned: true,

--- a/lib/view/info_view.dart
+++ b/lib/view/info_view.dart
@@ -42,9 +42,9 @@ class InfoView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: appBackground,
+      backgroundColor: AppColors.appBackground,
       appBar: AppBar(
-        backgroundColor: appBarColor,
+        backgroundColor: AppColors.appBarBackground,
         iconTheme: appBarIconTheme,
         title: Text(
           title,

--- a/lib/view/ppe/ppe_view.dart
+++ b/lib/view/ppe/ppe_view.dart
@@ -14,7 +14,6 @@ class PPEView extends StatefulWidget {
 class _PPEViewState extends State<PPEView> {
   final title = 'PPE';
 
-  final color = Color.fromRGBO(255, 255, 255, 0.94);
   VideoPlayerController _videoController1;
   ChewieController _chewieController1;
 
@@ -24,12 +23,12 @@ class _PPEViewState extends State<PPEView> {
   final puttingOnCards = <ReusableCard>[
     ReusableCard(
       title: 'Step By Step Guide',
-      color: backgroundGreen,
+      color: AppColors.backgroundGreen,
       height: PPEView._cardHeight,
     ),
     ReusableCard(
       title: 'Infographic',
-      color: backgroundGreen,
+      color: AppColors.backgroundGreen,
       height: PPEView._cardHeight,
     )
   ];
@@ -37,12 +36,12 @@ class _PPEViewState extends State<PPEView> {
   final takingOffCards = <ReusableCard>[
     ReusableCard(
       title: 'Step By Step Guide',
-      color: backgroundBrown,
+      color: AppColors.backgroundBrown,
       height: PPEView._cardHeight,
     ),
     ReusableCard(
       title: 'Infographic',
-      color: backgroundBrown,
+      color: AppColors.backgroundBrown,
       height: PPEView._cardHeight,
     )
   ];
@@ -73,9 +72,9 @@ class _PPEViewState extends State<PPEView> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: color,
+      backgroundColor: AppColors.appBackground,
       appBar: AppBar(
-        backgroundColor: appBarColor,
+        backgroundColor: AppColors.appBarBackground,
         iconTheme: appBarIconTheme,
         title: Text(
           title,

--- a/lib/view/sbs_guide_view.dart
+++ b/lib/view/sbs_guide_view.dart
@@ -9,7 +9,7 @@ class SBSGuideView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: appBarColor,
+      backgroundColor: AppColors.appBarBackground,
       appBar: AppBar(
         backgroundColor: Colors.white,
         iconTheme: appBarIconTheme,

--- a/lib/view/staff_welfare/staff_welfare_view.dart
+++ b/lib/view/staff_welfare/staff_welfare_view.dart
@@ -24,7 +24,7 @@ class StaffWelfareView extends StatelessWidget {
     return Scaffold(
       backgroundColor: color,
       appBar: AppBar(
-        backgroundColor: appBarColor,
+        backgroundColor: AppColors.appBarBackground,
         iconTheme: appBarIconTheme,
         title: Text(
           title,


### PR DESCRIPTION
Adds new color palette from #9. Still needs some re-organising but first step in centralising the colors into one file.

## Screenshots

Before:
<img width="424" alt="Screen Shot 2020-03-22 at 11 25 45 pm" src="https://user-images.githubusercontent.com/869261/77283981-bc605680-6d21-11ea-9baa-04b2a3a84ac4.png">

After:
<img width="424" alt="Screen Shot 2020-03-23 at 4 15 29 pm" src="https://user-images.githubusercontent.com/869261/77284136-152fef00-6d22-11ea-8197-fd418a3f7b10.png">

## Things to note

There are a few colors that had no equivalent in the new palette. I marked them with a TODO to decide what should happen (either update to one of the ones in the palette or add to the palette).