### PR TITLE
lets get things back on track with 1st basic test

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -5,10 +5,14 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
-// import 'package:flutter/material.dart';
-// import 'package:flutter_test/flutter_test.dart';
-
-// import 'package:wh_covid19/main.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wh_covid19/main.dart';
 
 void main() {
+  testWidgets('show WH org name on home page', (tester) async {
+    // dont use _initApp as for this we *dont* want the future to complete yet
+    await tester.pumpWidget(MyApp());
+
+    expect(find.text('Western Health'), findsOneWidget);
+  });
 }


### PR DESCRIPTION
This adds back at least the first basic widget test.

We don't have much in the way of business logic to test at the moment, but now that we have some initial parts of the app built out, we should be at least adding some widget test to make sure content is shown as expected and user nav goes on the correct routes.

Also beta channel Flutter now returns non zero exit code if we run flutter test with no tests defined.