### PR TITLE
Update disclaimer

### DIFF
--- a/lib/hard_data.dart
+++ b/lib/hard_data.dart
@@ -121,7 +121,7 @@ The authors of this app have made efforts to ensure the information is up to dat
 
 The authors accept no responsibility for any information perceived as misleading or the success of any treatment regimen detailed in the guidelines.
 
-The app is made available on the understanding that Western Health and its employees shall have no liability (including liability by reason of negligence) to the users for any loss, damage, cost or expense incurred or arising by reason of any person using or relying on the information and whether caused by reason of any error, negligent act, omission or misinterpretation in the app or otherwise.
+The app is made available on the understanding that Western Health, Western Health employees, the designers, developers, testers, reviewers, organisers and all other contributors to the project have have no liability (including liability by reason of negligence) to the users for any loss, damage, cost or expense incurred or arising by reason of any person using or relying on the information and whether caused by reason of any error, negligent act, omission or misinterpretation in the app or otherwise.
 
 The Western Health trademark and app cannot be copied, modified, reproduced, published, uploaded, distributed or posted without the prior written consent of Western Health.
 


### PR DESCRIPTION
Issue #118 that includes designers, developers, testers, reviewers, organisers and all other contributors under the "no liability" section.

## Screenshots
<img width="584" alt="Screen Shot 2020-03-29 at 5 39 29 pm" src="https://user-images.githubusercontent.com/12321678/77842998-676e8580-71e4-11ea-8f69-23f06d1917e4.png">
