### PR TITLE
Fill out intubation guidance screen

### DIFF
--- a/lib/hard_data.dart
+++ b/lib/hard_data.dart
@@ -263,6 +263,7 @@ const List<IntubationContent> intubationGuide = [
     IntubationSection(items: [
       IntubationItem('As per WH guidelines',
           subtitle: 'See step-by-step guide'),
+      // ignore: prefer_single_quotes
       IntubationItem("“Buddy system” - use a Spotter", icon: '😊'),
       IntubationItem('Airway operator, Assistant, Team Leader'),
       IntubationItem('Airway operator consider double gloves'),

--- a/lib/hard_data.dart
+++ b/lib/hard_data.dart
@@ -279,8 +279,7 @@ const List<IntubationContent> intubationGuide = [
           'Attached to manual ventilation device or Anaesthetic machine'),
       IntubationItem('2-handed vice grip'),
       IntubationItem('Ensure square etCO2 waveform'),
-      IntubationItem(
-          'Attached to manual ventilation device or Anaesthetic machine',
+      IntubationItem('Avoid manual bagging unless rescue oxygenation',
           icon: '❌'),
     ])
   ]),

--- a/lib/hard_data.dart
+++ b/lib/hard_data.dart
@@ -2,8 +2,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show rootBundle;
 
-import 'models/intubation_guide.dart';
 import 'models/PPEStepInfo.dart';
+import 'models/intubation_guide.dart';
 import 'routes.dart';
 import 'style.dart';
 import 'widget/reusable_card.dart';

--- a/lib/hard_data.dart
+++ b/lib/hard_data.dart
@@ -2,6 +2,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show rootBundle;
 
+import 'models/intubation_guide.dart';
 import 'models/PPEStepInfo.dart';
 import 'routes.dart';
 import 'style.dart';
@@ -237,6 +238,81 @@ const List<PPEStepInfo> ppeOffMethod2Steps = [
         'Discard in a waste container'
       ]),
   handHygieneStep,
+];
+
+const List<IntubationContent> intubationGuide = [
+  IntubationContent('Planning', [
+    IntubationSection(items: [
+      IntubationItem('Intervene Early'),
+      IntubationItem('Negative pressure room', subtitle: 'If possible'),
+      IntubationItem('Meticulous airway assessment'),
+      IntubationItem('Discuss ventilation plan',
+          subtitle: 'Protective lung ventilation', icon: '💬'),
+    ])
+  ]),
+  IntubationContent('Prepare', [
+    IntubationSection(items: [
+      IntubationItem('Assemble airway team', subtitle: 'See checklist'),
+      IntubationItem('Allocate roles & Share airway',
+          subtitle: 'See checklist'),
+      IntubationItem('Use COVID-19 Intubation tray', subtitle: 'See checklist'),
+      IntubationItem('Ensure Viral filter and etCO2 in ventilation circuit'),
+    ])
+  ]),
+  IntubationContent('PPE', [
+    IntubationSection(items: [
+      IntubationItem('As per WH guidelines',
+          subtitle: 'See step-by-step guide'),
+      IntubationItem("“Buddy system” - use a Spotter", icon: '😊'),
+      IntubationItem('Airway operator, Assistant, Team Leader'),
+      IntubationItem('Airway operator consider double gloves'),
+    ])
+  ]),
+  IntubationContent('Pre-oxygenation', [
+    IntubationSection(items: [
+      IntubationItem('45-degree head-up position'),
+      IntubationItem(
+          'Stop high flow O2 via HFNP, NP, facemark or non-rebreather',
+          icon: '❌'),
+      IntubationItem('Use Best-fitting Face mask'),
+      IntubationItem(
+          'Attached to manual ventilation device or Anaesthetic machine'),
+      IntubationItem('2-handed vice grip'),
+      IntubationItem('Ensure square etCO2 waveform'),
+      IntubationItem(
+          'Attached to manual ventilation device or Anaesthetic machine',
+          icon: '❌'),
+    ])
+  ]),
+  IntubationContent('Perform', [
+    IntubationSection(name: 'Induction', items: [
+      IntubationItem('Modified RSI technique'),
+      IntubationItem('Generous dosing of NMBA',
+          subtitle:
+              '• Rocuronium >1.5mg/kg IBW or\n• Suxamethonium 1.5mg/kg IBW'),
+      IntubationItem('Minimise apnoea time while minimising risk of cough',
+          icon: '⚖'),
+      IntubationItem('Avoid ventilation unless rescue oxygenation', icon: '❌'),
+    ]),
+    IntubationSection(name: 'Intubation', items: [
+      IntubationItem('Use Videolaryngoscope CMAC'),
+      IntubationItem('Indirect view'),
+      IntubationItem('Tube to correct depth 1st time',
+          subtitle: 'Cuff manometry not required'),
+      IntubationItem('Inflate cuff before ventilation', icon: '🛑'),
+      IntubationItem('Generously inflate cuff'),
+    ])
+  ]),
+  IntubationContent('Post-ETT', [
+    IntubationSection(items: [
+      IntubationItem('Consider placing NG tube'),
+      IntubationItem(
+          'Remove outer gloves, dispose of airway equipment in sealed bag',
+          icon: '🛑'),
+      IntubationItem('PPE removed as per WH guidelines', icon: '🛑'),
+      IntubationItem('Debrief and share lessons', icon: '💬'),
+    ])
+  ])
 ];
 
 // Feedback form

--- a/lib/models/intubation_guide.dart
+++ b/lib/models/intubation_guide.dart
@@ -1,0 +1,22 @@
+/// Data structure consisting of a section title,
+/// then list of sections containing icon, title and subtitle.
+///
+/// Used for intubation guide.
+class IntubationContent {
+  final String name;
+  final List<IntubationSection> sections;
+
+  const IntubationContent(this.name, this.sections);
+}
+
+class IntubationSection {
+  final String name;
+  final List<IntubationItem> items;
+
+  const IntubationSection({this.name, this.items});
+}
+
+class IntubationItem {
+  final String icon, title, subtitle;
+  const IntubationItem(this.title, {this.subtitle, this.icon = '✅'});
+}

--- a/lib/style.dart
+++ b/lib/style.dart
@@ -12,6 +12,7 @@ abstract class AppColors {
   static const Color backgroundBrown = Color(0xffd3ca92);
   static const Color majorText = blackAlpha900;
   static const Color minorText = blackAlpha600;
+  static const Color tabBarDeselectedText = Color.fromRGBO(0, 0, 0, 0.32);
 
   static const Color appBarIcon = blackAlpha900;
   static const Color homeAppBarIcon = Colors.white;

--- a/lib/view/intubation/guidance/intubation_guidance_page.dart
+++ b/lib/view/intubation/guidance/intubation_guidance_page.dart
@@ -1,19 +1,34 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
-
+import '../../view_templates/intubation_content_view_template.dart';
+import '../../../hard_data.dart';
+import '../../../models/intubation_guide.dart';
 import '../../../style.dart';
 
 class IntubationGuidancePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Intubation Guide'),
-      ),
-      body: Container(
-        color: AppColors.backgroundGreen,
-        child: const Center(
-          child: Text('TODO'),
+    return DefaultTabController(
+      length: intubationGuide.length,
+      child: Scaffold(
+        appBar: AppBar(
+          backgroundColor: AppColors.green50,
+          title: const Text('Intubation Guide'),
+          textTheme: Theme.of(context).textTheme,
+          iconTheme: IconThemeData(color: AppColors.appBarIcon),
+          bottom: TabBar(
+            labelColor: AppColors.blackAlpha800,
+            labelStyle: AppStyles.textSemiBold,
+            unselectedLabelColor: AppColors.blackAlpha800.withOpacity(0.32),
+            indicatorColor: AppColors.green900,
+            tabs: intubationGuide.map((e) => Tab(text: e.name)).toList(),
+            isScrollable: true,
+          ),
+        ),
+        body: TabBarView(
+          children: intubationGuide
+              .map((e) => IntubationContentViewTemplate(content: e))
+              .toList(),
         ),
       ),
     );

--- a/lib/view/intubation/guidance/intubation_guidance_page.dart
+++ b/lib/view/intubation/guidance/intubation_guidance_page.dart
@@ -1,9 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
-import '../../view_templates/intubation_content_view_template.dart';
 import '../../../hard_data.dart';
-import '../../../models/intubation_guide.dart';
 import '../../../style.dart';
+import '../../view_templates/intubation_content_view_template.dart';
 
 class IntubationGuidancePage extends StatelessWidget {
   @override

--- a/lib/view/intubation/guidance/intubation_guidance_page.dart
+++ b/lib/view/intubation/guidance/intubation_guidance_page.dart
@@ -19,7 +19,7 @@ class IntubationGuidancePage extends StatelessWidget {
           bottom: TabBar(
             labelColor: AppColors.blackAlpha800,
             labelStyle: AppStyles.textSemiBold,
-            unselectedLabelColor: AppColors.blackAlpha800.withOpacity(0.32),
+            unselectedLabelColor: AppColors.tabBarDeselectedText,
             indicatorColor: AppColors.green900,
             tabs: intubationGuide.map((e) => Tab(text: e.name)).toList(),
             isScrollable: true,

--- a/lib/view/intubation/guidance/intubation_guidance_page.dart
+++ b/lib/view/intubation/guidance/intubation_guidance_page.dart
@@ -15,7 +15,7 @@ class IntubationGuidancePage extends StatelessWidget {
           backgroundColor: AppColors.green50,
           title: const Text('Intubation Guide'),
           textTheme: Theme.of(context).textTheme,
-          iconTheme: IconThemeData(color: AppColors.appBarIcon),
+          iconTheme: AppStyles.appBarIconTheme,
           bottom: TabBar(
             labelColor: AppColors.blackAlpha800,
             labelStyle: AppStyles.textSemiBold,

--- a/lib/view/view_templates/intubation_content_view_template.dart
+++ b/lib/view/view_templates/intubation_content_view_template.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import '../../models/intubation_guide.dart';
+import '../../style.dart';
+
+///
+/// Renders a IntubationContent item, which is a data structure
+/// consisting of a section title,
+/// then list of sections containing icon, title and subtitle.
+class IntubationContentViewTemplate extends StatelessWidget {
+  final List<Object> flatItems;
+
+  IntubationContentViewTemplate({Key key, IntubationContent content})
+      : flatItems = content.sections
+            .expand((e) => [if (e.name != null) e, ...e.items])
+            .toList(),
+        super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: AppColors.backgroundGreen,
+      child: ListView.builder(
+        itemCount: flatItems.length,
+        itemBuilder: (context, index) {
+          final item = flatItems[index];
+          if (item is IntubationItem) {
+            return Card(
+                margin: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+                shape: const RoundedRectangleBorder(
+                    borderRadius: BorderRadius.all(Radius.circular(8))),
+                child: Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Stack(
+                      children: <Widget>[
+                        Text(
+                          item.icon,
+                          style: AppStyles.textH4,
+                        ),
+                        Padding(
+                          padding: const EdgeInsets.only(left: 40),
+                          child: Column(
+                            mainAxisAlignment: MainAxisAlignment.start,
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(item.title, style: AppStyles.textH4),
+                              if (item.subtitle != null) ...[
+                                const SizedBox(height: 4),
+                                Text(item.subtitle)
+                              ],
+                            ],
+                          ),
+                        )
+                      ],
+                    )));
+          } else if (item is IntubationSection) {
+            return Padding(
+                padding: const EdgeInsets.fromLTRB(16, 24, 16, 0),
+                child: Text(item.name, style: AppStyles.textH4));
+          } else {
+            throw 'Invalid IntubationContent item type $item';
+          }
+        },
+      ),
+    );
+  }
+}

--- a/lib/view/view_templates/intubation_content_view_template.dart
+++ b/lib/view/view_templates/intubation_content_view_template.dart
@@ -58,7 +58,7 @@ class IntubationContentViewTemplate extends StatelessWidget {
                 padding: const EdgeInsets.fromLTRB(16, 24, 16, 0),
                 child: Text(item.name, style: AppStyles.textH4));
           } else {
-            throw 'Invalid IntubationContent item type $item';
+            throw Exception('Invalid IntubationContent item type $item');
           }
         },
       ),


### PR DESCRIPTION
Intubation guidance screen

6 pages of intubation guidance, in horizontally swipeable tab form, for #37 

## Changes

- `models\intubation_guide.dart` has simple reusable data structure consisting of a section title, then list of sections containing icon, title and subtitle. This structure could easily be converted to json in the future if necessary.
-`view_templates\intubation_content_view_template.dart` Renders a IntubationContent screen.
-These could both be easily reused if there are other similar screens.

## Screenshots
![image](https://user-images.githubusercontent.com/15306325/77918653-e993a280-72e7-11ea-97a9-b5b7a964faad.png)



## Things to note

I used a different emoji for "Minimise apnoea time while minimising risk of cough ⚖️" because 🤏 was only added to unicode last year. Instead, I moved the scales ⚖️ from the title to the leading icon ⚖ . See screenshot.