### PR TITLE
Add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Codeowners file, which will make sure we have some good defaults for who gets assigned to PRs.  
+
+# Mike, Maks and Bramley get everything by default
+*   @workerbee22 @maks @rockgecko-development  
+
+# For docs, I also get added to the list
+/docs/   @workerbee22 @maks @rockgecko-development @lukesleeman
+

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,6 @@
 # Mike, Maks and Bramley get everything by default
 *   @workerbee22 @maks @rockgecko-development  
 
-# For docs, I also get added to the list
-/docs/   @workerbee22 @maks @rockgecko-development @lukesleeman
+# For docs, Kim and I also get added to the list
+/docs/   @workerbee22 @maks @rockgecko-development @lukesleeman @kimngyn 
 


### PR DESCRIPTION
This change sets some default assignees on PRs

## Changes

- @workerbee22 @maks @rockgecko-development  for everything
- @workerbee22 @maks @rockgecko-development @lukesleeman @kimngyn  for `docs`
