### PR TITLE
Fixed disclaimer tests x 3 

### DIFF
--- a/lib/intro_router.dart
+++ b/lib/intro_router.dart
@@ -31,7 +31,7 @@ class _IntroRouterState extends State<IntroRouter> {
     // the version of the disclaimer the user agreed to is not the latest version of the disclaimer.
     // Users should not be able to access the app if they have not agreed to the latest version of the disclaimer,
     // which may be updated over time.
-    if (disclaimerAgreedOnDevice == true && disclaimerVersionOnDevice == Strings.disclaimerVersion) {
+    if (disclaimerAgreedOnDevice == true && disclaimerVersionOnDevice == Strings.disclaimerCurrentVersion) {
       await Navigator.of(context).pushReplacementNamed(Routes.home);
     } else {
       await Navigator.of(context).pushReplacementNamed(Routes.disclaimer);

--- a/lib/strings.dart
+++ b/lib/strings.dart
@@ -19,7 +19,12 @@ This app is designed to be used by Anaesthetic and Critical Care doctors at West
   // *** WARNING ***
   // Increment by one when the disclaimerBody changes. This will force users to accept/re-accept the disclaimer again
   // if they have previously accepted it. If the disclaimer has changed then users need to re-accept it.
-  static const String disclaimerVersion = '1';
+  static const String disclaimerCurrentVersion = '1';
   static const String disclaimerButtonAgreeText = 'I Agree';
   static const String disclaimerHaveAgreedText = 'You have agreed to the disclaimer';
+
+  /// Home strings
+  static const String homeHeading1 = 'Look After Yourself';
+  static const String homeHeading2 = 'Airway';
+  static const String homeHeading3 = 'ICU';
 }

--- a/lib/view/disclaimer_view.dart
+++ b/lib/view/disclaimer_view.dart
@@ -18,7 +18,7 @@ class _DisclaimerViewState extends State<DisclaimerView> {
   Future<void> _setAgreed() async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(Strings.settingDisclaimerAgreed, true);
-    await prefs.setString(Strings.settingDisclaimerVersion, Strings.disclaimerVersion);
+    await prefs.setString(Strings.settingDisclaimerVersion, Strings.disclaimerCurrentVersion);
     await prefs.setString(Strings.settingDisclaimerAgreedDateTime, DateTime.now().toString());
   }
 
@@ -180,7 +180,8 @@ class _DisclaimerViewState extends State<DisclaimerView> {
                         mainAxisAlignment: MainAxisAlignment.center,
                         crossAxisAlignment: CrossAxisAlignment.stretch,
                         children: <Widget>[
-                          if (snapshot.data.agreed == false || snapshot.data.version != Strings.disclaimerVersion)
+                          if (snapshot.data.agreed == false ||
+                              snapshot.data.version != Strings.disclaimerCurrentVersion)
                             _agreeButton(context)
                           else
                             _agreedMessage(context, snapshot.data.version, snapshot.data.dateStamp),

--- a/lib/view/home_page.dart
+++ b/lib/view/home_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 
 import '../hard_data.dart';
+import '../strings.dart';
 import '../style.dart';
 import '../utils/color.dart';
 import '../widget/card_container.dart';
@@ -40,15 +41,15 @@ class _HomePageState extends State<HomePage> {
       delegate: SliverChildListDelegate(const [
         SizedBox(height: 12),
         CardContainer(
-          title: 'Look After Yourself',
+          title: Strings.homeHeading1,
           cards: staffWelfare,
         ),
         CardContainer(
-          title: 'Airway',
+          title: Strings.homeHeading2,
           cards: intubation,
         ),
         CardContainer(
-          title: 'ICU',
+          title: Strings.homeHeading3,
           cards: icu,
         ),
         // Make sure the bottom CardContainer has room to breathe.

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -5,25 +5,39 @@ import 'package:wh_covid19/main.dart';
 import 'package:wh_covid19/strings.dart';
 
 void main() {
+  /// Initial Router Tests
   testWidgets('IntroRouter gets created on app start', (tester) async {
     await tester.pumpWidget(const MyApp());
     expect(find.byType(IntroRouter), findsOneWidget);
   });
 
-  testWidgets('Show disclaimer if user has not previously accepted it', (tester) async {
+  /// Disclaimer Tests
+  testWidgets('Show Disclaimer if user has not previously accepted it', (tester) async {
     SharedPreferences.setMockInitialValues(<String, dynamic>{});
     await tester.pumpWidget(const MyApp());
     await tester.pumpAndSettle(const Duration(seconds: 3));
     expect(find.text(Strings.disclaimerTitle), findsOneWidget);
   });
 
-  // TODO - Issue here running > 1 SharedPReferences tests as more tests than just this need to be added
-//  testWidgets('Show home screen if user has previously accepted disclaimer', (tester) async {
-//    SharedPreferences.setMockInitialValues(<String, dynamic>{'flutter.disclaimer_agreed': true});
-//    SharedPreferences.setMockInitialValues(<String, dynamic>{'flutter.disclaimer_version': '1'});
-//    await tester.pumpWidget(const MyApp());
-//    await tester.pumpAndSettle(const Duration(seconds: 3));
-//    expect(find.text('Look After Yourself'), findsOneWidget);
-//    expect(find.text('Airway'), findsOneWidget);
-//  });
+  testWidgets('Show Disclaimer screen if disclaimer current version does not match previously accepted version',
+      (tester) async {
+    SharedPreferences.setMockInitialValues(<String, dynamic>{
+      'flutter.${Strings.settingDisclaimerAgreed}': true,
+      'flutter.${Strings.settingDisclaimerVersion}': '-1',
+    });
+    await tester.pumpWidget(const MyApp());
+    await tester.pumpAndSettle(const Duration(seconds: 3));
+    expect(find.text(Strings.disclaimerTitle), findsOneWidget);
+  });
+
+  testWidgets('Show Home screen if user has previously accepted disclaimer', (tester) async {
+    SharedPreferences.setMockInitialValues(<String, dynamic>{
+      'flutter.${Strings.settingDisclaimerAgreed}': true,
+      'flutter.${Strings.settingDisclaimerVersion}': '${Strings.disclaimerCurrentVersion}',
+    });
+    await tester.pumpWidget(const MyApp());
+    await tester.pumpAndSettle(const Duration(seconds: 3));
+    expect(find.text(Strings.homeHeading1), findsOneWidget);
+    expect(find.text(Strings.homeHeading2), findsOneWidget);
+  });
 }


### PR DESCRIPTION
Fixed the Disclaimer widget tests for app startup behaviour (thanks to @maks for a fix).

## Changes

Widget tests for disclaimer are now: 

- Tests for correct app startup screen either home or disclaimer
- Disclaimer shown if user has never agreed to disclaimer or version flag has changed since they approved previously
- Home shown if they have agreed to the disclaimer and version flag matches the current version of the disclaimer in the app

## Things to note

Tests now use Strings class string values, rather than hard coded text in the test. This should make code to test mismatches in text less likely. For example a title could change in Strings class and this would be reflected in the UI and also used by the tests.

Home screen code updated to use Strings class value for the UI code.
