### PR TITLE
Fixed iOS setting to set the 'Export Compliance' 

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -41,5 +41,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>ITSAppUsesNonExemptEncryption</key>
+    <false/>
 </dict>
 </plist>


### PR DESCRIPTION
Currently I have to manually set the export compliance in TestFlight before iOS releases are available to test. This fix should remove that manual step.

## Changes

- iOS only change Info.plist add setting

No other changes. Re tested on iOS and Android correctly, no issues.