### PR TITLE
[Enhancement] Remove a Step in Pre-oxygenation Tab

### DIFF
--- a/lib/hard_data.dart
+++ b/lib/hard_data.dart
@@ -347,8 +347,6 @@ const List<IntubationContent> intubationGuide = [
           'Stop high flow O2 via HFNP, NP, facemark or non-rebreather',
           icon: '❌'),
       IntubationItem('Use Best-fitting Face mask'),
-      IntubationItem(
-          'Attached to manual ventilation device or Anaesthetic machine'),
       IntubationItem('2-handed vice grip'),
       IntubationItem('Ensure square etCO2 waveform'),
       IntubationItem('Avoid manual bagging unless rescue oxygenation',


### PR DESCRIPTION
Resolved #158

## Abstract
This PR will remove the dot point "Attached to manual ventilation device or Anaesthetic machine." in intubation guide Pre-oxygenation tab.

## Changes

- Remove "Attached to manual ventilation device or Anaesthetic machine." under Pre-oxygenation tab

## Screenshots

![Simulator Screen Shot - iPhone 11 Pro - 2020-04-04 at 17 36 24](https://user-images.githubusercontent.com/14011195/78420432-e5c2a000-769a-11ea-8e0e-49e03419b905.png)
