### PR TITLE
Replace Information Screen's "Lorem Ipsum" with proper copy

### DIFF
--- a/lib/view/info_view.dart
+++ b/lib/view/info_view.dart
@@ -106,7 +106,7 @@ class InfoView extends StatelessWidget {
       const Padding(
         padding: EdgeInsets.all(8.0),
         child: Text(
-            'About this app. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Purus gravida quis blandit turpis cursus in hac habitasse platea. In vitae turpis massa sed elementum tempus. Pulvinar neque laoreet suspendisse interdum consectetur libero.'),
+            'This app aims to help safeguard the welfare of Western Health anaesthetists working amidst the COVID-19 pandemic by providing the most up-to-date information for time-critical procedures to ensure optimal patient care.'),
       ),
     ];
   }


### PR DESCRIPTION
This PR will resolve #166 by replacing the “Lorem Ipsum” copy in the app’s Information Screen with more appropriate copy about the app.

## Changes

Updates the Information Screen (`info_view.dart`) to use the following copy, sourced from the repo's README intro paragraph:

> This app aims to help safeguard the welfare of Western Health anaesthetists working amidst the COVID-19 pandemic by providing the most up-to-date information for time-critical procedures to ensure optimal patient care.

## Screenshots

![Simulator Screen Shot - iPhone 11 Pro Max - 2020-04-04 at 21 31 02](https://user-images.githubusercontent.com/1712450/78424973-df452000-76bc-11ea-9113-abae3daaddb9.png)


