### PR TITLE
[WIP] Potential fix for the app bar flashing

### DIFF
--- a/lib/view/home_page.dart
+++ b/lib/view/home_page.dart
@@ -84,6 +84,7 @@ class _HomePageState extends State<HomePage> {
     final percentage = scrollPos < appBarBottom
         ? ((scrollPos) / appBarBottom.toDouble())
         : 1.00;
+    final elevation = percentage < 1.00 ? 0.00 : 4.00;
 
     return Builder(builder: (context) {
       final _scrollController = PrimaryScrollController.of(context);
@@ -127,6 +128,7 @@ class _HomePageState extends State<HomePage> {
             floating: true,
             pinned: true,
             snap: false,
+            elevation: elevation,
           ),
           _renderList(context)
         ],


### PR DESCRIPTION
There appears to be this weird flashing of the app bar under iOS as the user scrolls down.

Under android the colour of the app bar as the user scrolls is darker than it should be.

I suspect both of these issues are caused by the elevation of the app bar.  It seems to change from 0 to fully elevated once its colour is not transparent.

This fix changes the elevation so it only switches to elevated once the app bar background colour is fully opaque.  🤞Hopefully this will resolve the flicker issue.

- [ ] `release-notes.txt` has been updated.

## Changes

- Only change elevation once the scroll transition is complete

## Screenshots

On android the colour of the app bar during the transition is not so dark 🎉:
![image](https://user-images.githubusercontent.com/902252/78972439-1d28c500-7b51-11ea-964b-084b8c263dcd.png)
## Things to note

I am not a flutter developer and I have no idea what I am doing 🤷‍♂️