### PR TITLE
Add a point to disclaimer about gathering analytics

### DIFF
--- a/lib/strings.dart
+++ b/lib/strings.dart
@@ -18,7 +18,7 @@ This app is designed to be used by the anaesthetist and critical care doctors at
   // *** WARNING ***
   // Increment by one when the disclaimerBody changes. This will force users to accept/re-accept the disclaimer again
   // if they have previously accepted it. If the disclaimer has changed then users need to re-accept it.
-  static const String disclaimerCurrentVersion = '3';
+  static const String disclaimerCurrentVersion = '4';
   static const String disclaimerButtonAgreeText = 'I Agree';
   static const String disclaimerHaveAgreedText =
       'You have agreed to the disclaimer';

--- a/lib/view/disclaimer_view.dart
+++ b/lib/view/disclaimer_view.dart
@@ -142,7 +142,8 @@ class _DisclaimerViewState extends State<DisclaimerView> {
                           child: Text(
                             'This is not a comprehensive source nor can we guarantee it is completely up to date at '
                             'the time of use 📱.\n\nIt is created using Western Health guidelines, informally '
-                            'peer-reviewed and adapted, with permission, from College/Society guidelines.\n\n',
+                            'peer-reviewed and adapted, with permission, from College/Society guidelines.\n\n'
+                            'WHAC19 gathers analytics and crash data which is used to improve the app.\n\n',
                             style: Styles.textP,
                           ),
                         ),


### PR DESCRIPTION
This Pr adds a single point to the disclaimer about analytics and crash reporting

## Changes

Under the "Please keep in mind section" I've added
> WHAC19 gathers analytics and crash data which is used to improve the app.

The disclaimer version has been bumped to 4

## Screenshots

![image](https://user-images.githubusercontent.com/902252/78973233-ce7c2a80-7b52-11ea-8575-b0b7390cefbc.png)

## Things to note

Nobody has agreed on this text!  This PR is just a bit of a straw-man for us to beat up on and hopefully improve!