### PR TITLE
[Fix] Rich Text Font Accessibilty

### DIFF
--- a/lib/view/disclaimer_view.dart
+++ b/lib/view/disclaimer_view.dart
@@ -108,8 +108,7 @@ class _DisclaimerViewState extends State<DisclaimerView> {
                           ' for this.',
                           style: Styles.textH5,
                         ),
-                        RichText(
-                            text: TextSpan(children: [
+                        Text.rich(TextSpan(children: [
                           const TextSpan(
                             text: '\n\nPlease refer to ',
                             style: Styles.textH5,


### PR DESCRIPTION
Resolved #227

## Abstract
This PR will fix the issue that the paragraph with hyperlink on Disclaimer Screen does not change the font size based on the accessibility setting. RichText is a low-level way to draw text and does not support font size accessibility. RichText should not be used in general.

## Changes

- Replace RichText with Text.rich

## Screenshots
**_Note that in the screenshot, the font size in accessibility is set to the smallest._**

![Simulator Screen Shot - iPhone 11 Pro - 2020-04-11 at 21 01 59](https://user-images.githubusercontent.com/14011195/79042070-f1ccd580-7c37-11ea-877a-23107a317309.png)

## Things to note
I haven't updated the disclaimer version because there's no text changes. It's just the style. To test it, the QA needs to delete the existing app and install it again to see the disclaimer page.