### PR TITLE
238 - Move UI config out of data layer

### DIFF
--- a/lib/hard_data.dart
+++ b/lib/hard_data.dart
@@ -11,7 +11,6 @@ import 'models/ventilation_guide.dart';
 import 'routes.dart';
 import 'strings.dart';
 import 'style.dart';
-import 'widget/reusable_card.dart';
 
 /// Web urls
 const String whURL = 'http://wh.cyphix.net/';
@@ -35,54 +34,38 @@ const List<HomeCard> staffWelfare = [
   )
 ];
 
-// Airway card list composition
-const List<ReusableCard> airway = [
-  ReusableCard(
+const List<HomeCard> airway = [
+  HomeCard(
     title: Strings.intubationGuideTitle,
     description: 'Step by step guide',
-    color: AppColors.backgroundGreen,
-    routeTo: Routes.intubationGuidance,
-    height: 70,
-    margin: EdgeInsets.all(0.0),
+    route: Routes.intubationGuidance,
   ),
-  ReusableCard(
+  HomeCard(
     title: Strings.intubationChecklistTitle,
     description: 'Checklist',
-    color: AppColors.backgroundGreen,
-    routeTo: Routes.intubationChecklist,
-    height: 70,
-    margin: EdgeInsets.all(0.0),
+    route: Routes.intubationChecklist,
   ),
-  ReusableCard(
+  HomeCard(
     title: Strings.extubationGuideTitle,
     description: 'Step by step guide',
-    color: AppColors.backgroundGreen,
-    routeTo: Routes.extubationGuidance,
-    height: 70,
-    margin: EdgeInsets.all(0.0),
+    route: Routes.extubationGuidance,
   )
 ];
 
 // ICU card list composition
-const List<ReusableCard> icu = [
-  ReusableCard(
+const List<HomeCard> icu = [
+  HomeCard(
     title: Strings.ventilationTitle,
     description: 'Description',
-    color: AppColors.backgroundBlue,
-    routeTo: Routes.ventilation,
-    margin: EdgeInsets.all(0.0),
+    route: Routes.ventilation,
   ),
-  ReusableCard(
+  HomeCard(
     title: Strings.dailyRoundTitle,
-    color: AppColors.backgroundBlue,
-    routeTo: Routes.generalCare,
-    margin: EdgeInsets.all(0.0),
+    route: Routes.generalCare,
   ),
-  ReusableCard(
+  HomeCard(
     title: Strings.tipsForCrossSkillingTitle,
-    color: AppColors.backgroundBlue,
-    routeTo: Routes.tipsJuniorStaff,
-    margin: EdgeInsets.all(0.0),
+    route: Routes.tipsJuniorStaff,
   ),
 ];
 

--- a/lib/hard_data.dart
+++ b/lib/hard_data.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+// import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show rootBundle;
 
 import 'models/IntubationChecklist.dart';
@@ -10,7 +10,6 @@ import 'models/intubation_guide.dart';
 import 'models/ventilation_guide.dart';
 import 'routes.dart';
 import 'strings.dart';
-import 'style.dart';
 
 /// Web urls
 const String whURL = 'http://wh.cyphix.net/';
@@ -77,12 +76,10 @@ const Map<String, HtmlTextScreenData> routeToScreenData = {
   Routes.ventilationInitialActions: HtmlTextScreenData(
     'Suggested initial actions',
     'assets/text/icu_ventilation_initial_actions_content.html',
-    AppColors.backgroundBlue,
   ),
   Routes.ventilationAdjuncts: HtmlTextScreenData(
     'Adjuncts',
     'assets/text/icu_ventilation_adjuncts_content.html',
-    AppColors.backgroundBlue,
   ),
 };
 
@@ -91,9 +88,8 @@ const Map<String, HtmlTextScreenData> routeToScreenData = {
 class HtmlTextScreenData {
   final String title;
   final String htmlFile;
-  final Color bgColor;
 
-  const HtmlTextScreenData(this.title, this.htmlFile, this.bgColor);
+  const HtmlTextScreenData(this.title, this.htmlFile);
 
   Future<String> readFile() async {
     return await rootBundle.loadString(htmlFile);

--- a/lib/hard_data.dart
+++ b/lib/hard_data.dart
@@ -1,9 +1,9 @@
-// A list of two cards
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show rootBundle;
 
 import 'models/IntubationChecklist.dart';
 import 'models/PPEStepInfo.dart';
+import 'models/home_card.dart';
 import 'models/icu_daily_round_checklist.dart';
 import 'models/icu_daily_round_steps.dart';
 import 'models/intubation_guide.dart';
@@ -21,21 +21,17 @@ const String whAnaestheticMicrositeURL =
 const String whIcuMicrositeURL = 'https://whicu2020.wixsite.com/icuquickguide';
 const String feedbackFormUrl = 'https://forms.gle/zQtfhvswrKmjJjNV7';
 
-// Staff Welfare card list composition
-const List<ReusableCard> staffWelfare = [
-  ReusableCard(
+//Staff Welfare card list composition
+const List<HomeCard> staffWelfare = [
+  HomeCard(
     title: Strings.ppeTitle,
     description: '3 guides',
-    color: Colors.white,
-    routeTo: Routes.ppe,
-    margin: EdgeInsets.all(0.0),
+    route: Routes.ppe,
   ),
-  ReusableCard(
+  HomeCard(
     title: Strings.yourWelfareTitle,
     description: 'Vital info & contacts',
-    color: Colors.white,
-    routeTo: Routes.staffWelfare,
-    margin: EdgeInsets.all(0.0),
+    route: Routes.staffWelfare,
   )
 ];
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -152,7 +152,7 @@ class MyApp extends StatelessWidget {
         if (snapshot.connectionState == ConnectionState.waiting) {
           return HtmlTextCardViewTemplate(
             title: data.title,
-            bgColor: data.bgColor,
+            bgColor: AppColors.backgroundBlue,
             html: '',
           );
         } else if (snapshot.hasError) {
@@ -160,7 +160,7 @@ class MyApp extends StatelessWidget {
         } else {
           return HtmlTextCardViewTemplate(
             title: data.title,
-            bgColor: data.bgColor,
+            bgColor: AppColors.backgroundBlue,
             html: snapshot.data,
           );
         }

--- a/lib/models/home_card.dart
+++ b/lib/models/home_card.dart
@@ -1,0 +1,7 @@
+class HomeCard {
+  final String title;
+  final String description;
+  final String route;
+
+  const HomeCard({this.title, this.description, this.route});
+}

--- a/lib/view/home_page.dart
+++ b/lib/view/home_page.dart
@@ -9,6 +9,7 @@ import '../utils/color.dart';
 import '../utils/firebase.dart';
 import '../utils/system_bars.dart';
 import '../widget/card_container.dart';
+import '../widget/reusable_card.dart';
 import 'info_view.dart';
 
 class HomePage extends StatefulWidget {
@@ -58,25 +59,33 @@ class _HomePageState extends State<HomePage> {
   Widget _renderList(BuildContext context) {
     return SliverList(
       delegate: SliverChildListDelegate(
-        const [
-          SizedBox(height: 12),
+        [
+          const SizedBox(height: 12),
           CardContainer(
             title: Strings.homeHeading1,
-            cards: staffWelfare,
+            cards: staffWelfare
+                .map(
+                  (c) => ReusableCard.fromData(
+                    card: c,
+                    color: Colors.white,
+                    margin: const EdgeInsets.all(0.0),
+                  ),
+                )
+                .toList(),
             containerLayout: CardsLayout.twoRow,
           ),
-          CardContainer(
+          const CardContainer(
             title: Strings.homeHeading2,
             cards: airway,
             containerLayout: CardsLayout.threeColumn,
           ),
-          CardContainer(
+          const CardContainer(
             title: Strings.homeHeading3,
             cards: icu,
             containerLayout: CardsLayout.threeDoubleRowBigTop,
           ),
           // Make sure the bottom CardContainer has room to breathe.
-          SizedBox(height: 12),
+          const SizedBox(height: 12),
         ],
       ),
     );

--- a/lib/view/home_page.dart
+++ b/lib/view/home_page.dart
@@ -74,14 +74,30 @@ class _HomePageState extends State<HomePage> {
                 .toList(),
             containerLayout: CardsLayout.twoRow,
           ),
-          const CardContainer(
+          CardContainer(
             title: Strings.homeHeading2,
-            cards: airway,
+            cards: airway
+                .map(
+                  (c) => ReusableCard.fromData(
+                    card: c,
+                    color: AppColors.backgroundGreen,
+                    margin: const EdgeInsets.all(0.0),
+                    height: 70,
+                  ),
+                )
+                .toList(),
             containerLayout: CardsLayout.threeColumn,
           ),
-          const CardContainer(
+          CardContainer(
             title: Strings.homeHeading3,
-            cards: icu,
+            cards: icu
+                .map(
+                  (c) => ReusableCard.fromData(
+                    card: c,
+                    color: AppColors.backgroundBlue,
+                  ),
+                )
+                .toList(),
             containerLayout: CardsLayout.threeDoubleRowBigTop,
           ),
           // Make sure the bottom CardContainer has room to breathe.

--- a/lib/widget/reusable_card.dart
+++ b/lib/widget/reusable_card.dart
@@ -5,6 +5,8 @@ import '../style.dart';
 import '../widget/cards/reusable_card_base.dart';
 
 class ReusableCard extends StatelessWidget {
+  static const double _defaultHeight = 84;
+
   /// Title of the card
   final String title;
 
@@ -36,19 +38,24 @@ class ReusableCard extends StatelessWidget {
     this.description,
     this.color = Colors.white,
     this.routeTo,
-    this.height = 84,
+    this.height = _defaultHeight,
     this.elevation = 4,
     this.fallback,
     this.margin = const EdgeInsets.all(4.0),
   });
 
-  ReusableCard.fromData({HomeCard card, Color color, EdgeInsets margin})
-      : this(
+  ReusableCard.fromData({
+    HomeCard card,
+    Color color,
+    EdgeInsets margin,
+    double height,
+  }) : this(
           title: card.title,
           description: card.description,
           routeTo: card.route,
           color: color,
           margin: margin,
+          height: height ?? _defaultHeight,
         );
 
   @override

--- a/lib/widget/reusable_card.dart
+++ b/lib/widget/reusable_card.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+
+import '../models/home_card.dart';
 import '../style.dart';
 import '../widget/cards/reusable_card_base.dart';
 
@@ -39,6 +41,15 @@ class ReusableCard extends StatelessWidget {
     this.fallback,
     this.margin = const EdgeInsets.all(4.0),
   });
+
+  ReusableCard.fromData({HomeCard card, Color color, EdgeInsets margin})
+      : this(
+          title: card.title,
+          description: card.description,
+          routeTo: card.route,
+          color: color,
+          margin: margin,
+        );
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
Refactor that removes all UI configuration from the data layer (which is currently just hardcoded in `hard_data.dart`)

## Screenshots

There should be no visual changes to the existing app as the refactor just cleans up the app code architecture.

Fixes: #238 