### PR TITLE
Fixed the Home page 'flickering' of the app bar

### DIFF
--- a/lib/view/home_page.dart
+++ b/lib/view/home_page.dart
@@ -108,66 +108,78 @@ class _HomePageState extends State<HomePage> {
   }
 
   Widget _renderBody(BuildContext context) {
-    const appBarHeight = 70;
-    const logoHeight = 42;
+    const appBarHeight = 70.0;
+    const logoHeight = 42.0;
 
-    final Widget mainLogo = SvgPicture.asset('assets/images/main_logo.svg',
-        height: logoHeight.toDouble());
-    final appBarBottom = appBarHeight.toDouble() - logoHeight.toDouble();
-    final scrollPos = _scrollPosition.round();
-    final percentage = scrollPos < appBarBottom
-        ? ((scrollPos) / appBarBottom.toDouble())
-        : 1.00;
+    final Widget mainLogo = SvgPicture.asset(
+      'assets/images/main_logo.svg',
+      height: logoHeight,
+    );
+    const appBarBottom = appBarHeight - logoHeight;
+    // On iOS scroll position can be negative due to over scroll
+    // So prevent negative scrollPos which results in a negative percentage
+    final scrollPos = _scrollPosition.isNegative ? 0.0 : _scrollPosition;
+    final percentage =
+        scrollPos < appBarBottom ? scrollPos / appBarBottom : 1.0;
 
-    return Builder(builder: (context) {
-      final _scrollController = PrimaryScrollController.of(context);
+    return Builder(
+      builder: (context) {
+        final _scrollController = PrimaryScrollController.of(context);
 
-      _scrollController.addListener(() {
-        setState(() {
-          _scrollPosition = _scrollController.position.pixels;
+        _scrollController.addListener(() {
+          setState(() {
+            _scrollPosition = _scrollController.position.pixels;
+          });
         });
-      });
 
-      return CustomScrollView(
-        slivers: <Widget>[
-          SliverAppBar(
-            // Warning brightness interacts with SystemUiOverlayStyle
-            // See system_bars.dart comments
-            brightness: Brightness.light,
-            automaticallyImplyLeading: false,
-            expandedHeight: appBarHeight.toDouble(),
-            bottom: PreferredSize(
-              preferredSize: Size.fromHeight(appBarHeight.toDouble()),
-              child: Padding(
-                padding: const EdgeInsets.fromLTRB(16, 0, 16, 4),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: <Widget>[
-                    mainLogo,
-                    GestureDetector(
-                      onTap: () => InfoView.navigateTo(context),
-                      child: Icon(
-                        Icons.info_outline,
-                        size: 24,
-                        color: generateIconColor(AppColors.homeAppBarIcon,
-                            AppColors.appBarIcon, percentage),
-                      ),
-                    )
-                  ],
+        return CustomScrollView(
+          slivers: <Widget>[
+            SliverAppBar(
+              // Warning brightness interacts with SystemUiOverlayStyle
+              // See system_bars.dart comments
+              brightness: Brightness.light,
+              primary: true,
+              automaticallyImplyLeading: false,
+              expandedHeight: appBarHeight,
+              centerTitle: false,
+              forceElevated: false,
+              elevation: 0.0,
+              backgroundColor: AppColors.dynamicAppBarBackground(percentage),
+              iconTheme: Styles.appBarIconTheme,
+              floating: true,
+              pinned: true,
+              snap: false,
+              bottom: PreferredSize(
+                preferredSize: const Size.fromHeight(appBarHeight),
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      mainLogo,
+                      GestureDetector(
+                        onTap: () => InfoView.navigateTo(context),
+                        child: Icon(
+                          Icons.info_outline,
+                          size: 24,
+                          color: generateIconColor(
+                            AppColors.homeAppBarIcon,
+                            AppColors.appBarIcon,
+                            percentage,
+                          ),
+                        ),
+                      )
+                    ],
+                  ),
                 ),
               ),
             ),
-            backgroundColor: AppColors.dynamicAppBarBackground(percentage),
-            iconTheme: Styles.appBarIconTheme,
-            floating: true,
-            pinned: true,
-            snap: false,
-          ),
-          _renderList(context)
-        ],
-      );
-    });
+            _renderList(context)
+          ],
+        );
+      },
+    );
   }
 
   @override


### PR DESCRIPTION
Fix for issue [242](https://github.com/Western-Health-Covid19-Collaboration/wh_covid19_app/issues/242)

## Abstract

- Fixed the 'flickering' of the app bar when scrolling on iOS
- Was due to over scroll on iOS permitting the scroll position to be negative

## Changes

- general cleanup of the SliverAppBar
- ensure that scroll position cannot be negative, because on iOS when overscrolling the value can be negative
- elevation on SliverAppBar and other cleanups

## Screenshots

See issue for the problem

## Things to note

Retested on Android and iOS.