### PR TITLE
[Fix] Emoji Alignment and Bottom Cut Off

### DIFF
--- a/lib/widget/lists/icu_daily_round_steps_card.dart
+++ b/lib/widget/lists/icu_daily_round_steps_card.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
+
 import '../../models/icu_daily_round_steps.dart';
 import '../../style.dart';
-
 import '../../widget/cards/reusable_card_base.dart';
 
 class ICUDailyRoundStepsCard extends StatelessWidget {
@@ -11,24 +11,54 @@ class ICUDailyRoundStepsCard extends StatelessWidget {
 
   Widget _renderItems(ICUDailyRoundItem item) {
     return Padding(
-      padding: const EdgeInsets.fromLTRB(4, 9, 16, 9),
+      padding: const EdgeInsets.fromLTRB(0, 0, 0, 16),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
-          Text(item.icon, style: Styles.textH4),
           Expanded(
-              child: Padding(
-                  padding: const EdgeInsets.fromLTRB(16, 0, 0, 0),
-                  child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(item.title, style: Styles.textH4),
-                        if (item.subtitle != null)
-                          Text(
-                            item.subtitle,
-                            style: Styles.textFooter,
-                          )
-                      ])))
+            flex: 10,
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(0, 0, 0, 0),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.start,
+                mainAxisSize: MainAxisSize.max,
+                children: [
+                  Text(
+                    item.icon,
+                    style: Styles.textH4,
+                  ),
+                ],
+              ),
+            ),
+          ),
+          Expanded(
+            flex: 90,
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(12, 2, 2, 2),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.start,
+                mainAxisSize: MainAxisSize.max,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.all(3.0),
+                    child: Text(
+                      item.title,
+                      style: Styles.textBody,
+                    ),
+                  ),
+                  if (item.subtitle != null)
+                    Padding(
+                      padding: const EdgeInsets.all(2.0),
+                      child: Text(
+                        item.subtitle,
+                        style: Styles.textFooter,
+                      ),
+                    )
+                ],
+              ),
+            ),
+          )
         ],
       ),
     );

--- a/lib/widget/lists/icu_daily_round_steps_card.dart
+++ b/lib/widget/lists/icu_daily_round_steps_card.dart
@@ -22,7 +22,7 @@ class ICUDailyRoundStepsCard extends StatelessWidget {
                   child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Text(item.title, style: Styles.textBody),
+                        Text(item.title, style: Styles.textH4),
                         if (item.subtitle != null)
                           Text(
                             item.subtitle,


### PR DESCRIPTION
Resloved #281 #282

## Abstract
This PR will fix the issue of improper alignment and bottom cut off the emojis. There might be some bug when flutter renders the emoji object. So for now, I just simply increase the title font size so that the container's height is good enough for displaying the whole emoji.

## Changes

- Use larger font size for the title

## Screenshots
![Simulator Screen Shot - iPhone 11 Pro - 2020-04-26 at 14 14 46](https://user-images.githubusercontent.com/14011195/80297641-4fc8f380-87c8-11ea-813c-d5c803937b4f.png)
