### PR TITLE
Minor updates to disclaimer

### DIFF
--- a/lib/strings.dart
+++ b/lib/strings.dart
@@ -18,7 +18,7 @@ This app is designed to be used by the anaesthetist and critical care doctors at
   // *** WARNING ***
   // Increment by one when the disclaimerBody changes. This will force users to accept/re-accept the disclaimer again
   // if they have previously accepted it. If the disclaimer has changed then users need to re-accept it.
-  static const String disclaimerCurrentVersion = '4';
+  static const String disclaimerCurrentVersion = '5';
   static const String disclaimerButtonAgreeText = 'I Agree';
   static const String disclaimerHaveAgreedText =
       'You have agreed to the disclaimer';

--- a/lib/view/disclaimer_view.dart
+++ b/lib/view/disclaimer_view.dart
@@ -142,7 +142,7 @@ class _DisclaimerViewState extends State<DisclaimerView> {
                             'This is not a comprehensive source nor can we guarantee it is completely up to date at '
                             'the time of use 📱.\n\nIt is created using Western Health guidelines, informally '
                             'peer-reviewed and adapted, with permission, from College/Society guidelines.\n\n'
-                            'WHAC19 gathers analytics and crash data which is used to improve the app.\n\n',
+                            'WHAC19 gathers analytics and crash data which is used to improve the app.  For more information and to opt out, go to Information > Privacy\n\n',
                             style: Styles.textP,
                           ),
                         ),

--- a/release_notes.txt
+++ b/release_notes.txt
@@ -1,3 +1,8 @@
+---- Sunday 2nd May, 2020 ----
+* Updates to disclaimer to point out privacy policy
+* Copy updates and tweaks from Gregg
+* Changes to layout of home screen and information section
+
 ---- Sunday 26th April, 2020 ----
 * Add Infographic Page for ALS/BLS Modifications
 


### PR DESCRIPTION
This makes some minor updates to the disclaimer to point out where to change the privacy settings as part of issue #241

- [x] `release-notes.txt` has been updated.

## Changes

- Updates to disclaimer
- While I'm at it, I've also put some missing things in the release notes

## Screenshots

<img width="404" alt="Screen Shot 2020-05-02 at 10 51 15 pm" src="https://user-images.githubusercontent.com/902252/80864665-7ce53c80-8cc7-11ea-9e08-079372e5fda5.png">

## Things to note

Until this PR is merged, the settings won't actually be present: https://github.com/Western-Health-Covid19-Collaboration/wh_covid19_app/pull/312