### PR TITLE
Make margins on home screen consistent

### DIFF
--- a/lib/view/home_page.dart
+++ b/lib/view/home_page.dart
@@ -66,7 +66,6 @@ class _HomePageState extends State<HomePage> {
                   (c) => ReusableCard.fromData(
                     card: c,
                     color: Colors.white,
-                    margin: const EdgeInsets.all(0.0),
                   ),
                 )
                 .toList(),
@@ -79,7 +78,6 @@ class _HomePageState extends State<HomePage> {
                   (c) => ReusableCard.fromData(
                     card: c,
                     color: AppColors.backgroundGreen,
-                    margin: const EdgeInsets.all(0.0),
                     height: 70,
                   ),
                 )

--- a/lib/view/home_page.dart
+++ b/lib/view/home_page.dart
@@ -78,7 +78,6 @@ class _HomePageState extends State<HomePage> {
                   (c) => ReusableCard.fromData(
                     card: c,
                     color: AppColors.backgroundGreen,
-                    height: 70,
                   ),
                 )
                 .toList(),

--- a/lib/widget/reusable_card.dart
+++ b/lib/widget/reusable_card.dart
@@ -6,6 +6,7 @@ import '../widget/cards/reusable_card_base.dart';
 
 class ReusableCard extends StatelessWidget {
   static const double _defaultHeight = 84;
+  static const EdgeInsets _defaultMargin = EdgeInsets.all(0.0);
 
   /// Title of the card
   final String title;
@@ -41,21 +42,21 @@ class ReusableCard extends StatelessWidget {
     this.height = _defaultHeight,
     this.elevation = 4,
     this.fallback,
-    this.margin = const EdgeInsets.all(4.0),
+    this.margin = _defaultMargin,
   });
 
   ReusableCard.fromData({
     HomeCard card,
     Color color,
-    EdgeInsets margin,
-    double height,
+    EdgeInsets margin = _defaultMargin,
+    double height = _defaultHeight,
   }) : this(
           title: card.title,
           description: card.description,
           routeTo: card.route,
           color: color,
           margin: margin,
-          height: height ?? _defaultHeight,
+          height: height,
         );
 
   @override


### PR DESCRIPTION
Resolved #314

## Abstract
This PR will fix the inconsistent gaps on home screen. This issue is because the incorrect way of setting the default value in `ReusableCard.fromData`. If you don't specify the margin in its constructor, it will pass `null` to the card.

## Changes

- Add default values for height and margin in the constructor of `ReusableCard.fromData`

## Screenshots

![Simulator Screen Shot - iPhone 11 Pro - 2020-05-02 at 23 01 51](https://user-images.githubusercontent.com/14011195/80864869-ef0a5100-8cc8-11ea-955b-4f8775091903.png)
