### PR TITLE
[Fix] UI Consistency - Cards Alignment Issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Western Health logos belong solely to Western Health may be subject to their cop
 
 For any urgent requests relating to this app you can contact luke.sleeman@gmail.com - It will go to Luke's phone.  You can also DM Luke through [GDG Melbourne's slack](http://bit.ly/join_gdgslack) - DM `@luke.sleeman`.
 
-## Acknowledgments
+## Acknowledgements
 
 So many people have worked together to make this project happen, and helped out in so many ways 🥰
 

--- a/lib/view/acknowledgements_view.dart
+++ b/lib/view/acknowledgements_view.dart
@@ -101,8 +101,8 @@ class HtmlSectionCard extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: <Widget>[
-        Padding(
-          padding: const EdgeInsets.fromLTRB(0, 24, 16, 0),
+        Container(
+          margin: const EdgeInsets.fromLTRB(4, 24, 16, 0),
           child: Text(
             title,
             style: Styles.textH4,

--- a/lib/view/icu_non_intensivist/tips_junior_staff_view.dart
+++ b/lib/view/icu_non_intensivist/tips_junior_staff_view.dart
@@ -85,8 +85,8 @@ class TipsJuniorStaffView extends StatelessWidget {
                       height: 48,
                     );
                   }
-                  return Padding(
-                    padding: const EdgeInsets.fromLTRB(0, 24, 16, 0),
+                  return Container(
+                    margin: const EdgeInsets.fromLTRB(4, 24, 16, 0),
                     child: Text(
                       e.toString(),
                       style: Styles.textH4,

--- a/lib/view/reference_view.dart
+++ b/lib/view/reference_view.dart
@@ -6,7 +6,7 @@ import '../style.dart';
 import '../widget/reusable_card.dart';
 
 class ReferenceView extends StatelessWidget {
-  final EdgeInsets _titlePadding = const EdgeInsets.fromLTRB(0, 24, 16, 0);
+  final EdgeInsets _titlePadding = const EdgeInsets.fromLTRB(4, 24, 16, 0);
   final EdgeInsets _contentPadding = const EdgeInsets.fromLTRB(16, 0, 16, 16);
   final double _sectionHeight = 48;
 
@@ -65,8 +65,8 @@ class ReferenceView extends StatelessWidget {
                 child: Column(
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
-                  Padding(
-                    padding: _titlePadding,
+                  Container(
+                    margin: _titlePadding,
                     child: const Text('References', style: Styles.textH4),
                   ),
                   ..._sections.map((e) =>

--- a/lib/view/resources/additional_resources_view.dart
+++ b/lib/view/resources/additional_resources_view.dart
@@ -69,8 +69,8 @@ class AdditionalResourcesView extends StatelessWidget {
                           height: 48,
                         );
                       }
-                      return Padding(
-                          padding: const EdgeInsets.fromLTRB(0, 24, 16, 0),
+                      return Container(
+                          margin: const EdgeInsets.fromLTRB(4, 24, 16, 0),
                           child: Text(
                             e.toString(),
                             style: Styles.textH4Light,

--- a/lib/widget/card_container.dart
+++ b/lib/widget/card_container.dart
@@ -7,8 +7,7 @@ enum CardsLayout { twoRow, threeColumn, threeDoubleRowBigTop, fourDoubleRow }
 
 class CardContainer extends StatelessWidget {
   static const double _outerPadding = 16;
-  static const double _innerPadding = 8;
-  static const double _headerPadding = 0;
+  static const double _headerPadding = 4;
 
   /// Title for the container
   final String title;
@@ -28,8 +27,8 @@ class CardContainer extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final containerHeading = title != null
-        ? Padding(
-            padding: const EdgeInsets.only(left: _headerPadding),
+        ? Container(
+            margin: const EdgeInsets.only(left: _headerPadding),
             child: Text(
               title,
               style: Styles.cardContainerTextStyle,
@@ -44,7 +43,6 @@ class CardContainer extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: <Widget>[
           containerHeading,
-          _buildVerticalSpacer(),
           _cardsLayout(containerLayout),
         ],
       ),
@@ -59,7 +57,6 @@ class CardContainer extends StatelessWidget {
           return Row(
             children: <Widget>[
               Expanded(child: cards[0]),
-              _buildHorizontalSpacer(),
               Expanded(child: cards[1]),
             ],
           );
@@ -75,9 +72,7 @@ class CardContainer extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
               cards[0],
-              _buildVerticalSpacer(),
               cards[1],
-              _buildVerticalSpacer(),
               cards[2]
             ],
           );
@@ -94,11 +89,9 @@ class CardContainer extends StatelessWidget {
               Row(children: <Widget>[
                 Expanded(child: cards[0]),
               ]),
-              _buildVerticalSpacer(),
               Row(
                 children: <Widget>[
                   Expanded(child: cards[1]),
-                  _buildHorizontalSpacer(),
                   Expanded(child: cards[2]),
                 ],
               )
@@ -117,14 +110,12 @@ class CardContainer extends StatelessWidget {
               Row(
                 children: <Widget>[
                   Expanded(child: cards[0]),
-                  _buildHorizontalSpacer(),
                   Expanded(child: cards[1]),
                 ],
               ),
               Row(
                 children: <Widget>[
                   Expanded(child: cards[2]),
-                  _buildHorizontalSpacer(),
                   Expanded(child: cards[3]),
                 ],
               )
@@ -139,10 +130,6 @@ class CardContainer extends StatelessWidget {
         return Container();
     }
   }
-
-  Widget _buildHorizontalSpacer() => Container(width: _innerPadding);
-
-  Widget _buildVerticalSpacer() => Container(height: _innerPadding);
 
   Widget _wrongCardsNumber() => const Center(
         child: Text(

--- a/lib/widget/card_container.dart
+++ b/lib/widget/card_container.dart
@@ -70,11 +70,7 @@ class CardContainer extends StatelessWidget {
           return Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             mainAxisSize: MainAxisSize.min,
-            children: <Widget>[
-              cards[0],
-              cards[1],
-              cards[2]
-            ],
+            children: <Widget>[cards[0], cards[1], cards[2]],
           );
         } else {
           return _wrongCardsNumber();

--- a/lib/widget/reusable_card.dart
+++ b/lib/widget/reusable_card.dart
@@ -6,7 +6,7 @@ import '../widget/cards/reusable_card_base.dart';
 
 class ReusableCard extends StatelessWidget {
   static const double _defaultHeight = 84;
-  static const EdgeInsets _defaultMargin = EdgeInsets.all(0.0);
+  static const EdgeInsets _defaultMargin = EdgeInsets.all(4.0);
 
   /// Title of the card
   final String title;


### PR DESCRIPTION
Resolved #325
## Abstract
This PR will fix the issue of broken constraints on reusable card section widget.

## Changes

- Changed the padding around the title to be margins
- Fixed the typo in README
- Offset the title left margin to be aligned with the card

## Screenshots
![Simulator Screen Shot - iPhone 11 Pro - 2020-05-05 at 20 04 31](https://user-images.githubusercontent.com/14011195/81055250-a8586900-8f0b-11ea-8c50-e1f19902c5e1.png)
![Simulator Screen Shot - iPhone 11 Pro - 2020-05-05 at 20 04 33](https://user-images.githubusercontent.com/14011195/81055257-abebf000-8f0b-11ea-9ea7-05f55269c902.png)