### PR TITLE
[Fix] Add spacing between items

### DIFF
--- a/lib/widget/lists/icu_daily_round_steps_card.dart
+++ b/lib/widget/lists/icu_daily_round_steps_card.dart
@@ -11,54 +11,54 @@ class ICUDailyRoundStepsCard extends StatelessWidget {
 
   Widget _renderItems(ICUDailyRoundItem item) {
     return Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          Expanded(
-            flex: 10,
-            child: Padding(
-              padding: const EdgeInsets.fromLTRB(0, 0, 0, 0),
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.start,
-                mainAxisSize: MainAxisSize.max,
-                children: [
-                  Text(
-                    item.icon,
-                    style: Styles.textH4,
-                  ),
-                ],
-              ),
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Expanded(
+          flex: 10,
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(0, 0, 0, 0),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.start,
+              mainAxisSize: MainAxisSize.max,
+              children: [
+                Text(
+                  item.icon,
+                  style: Styles.textH4,
+                ),
+              ],
             ),
           ),
-          Expanded(
-            flex: 90,
-            child: Padding(
-              padding: const EdgeInsets.fromLTRB(12, 2, 2, 2),
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.start,
-                mainAxisSize: MainAxisSize.max,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Padding(
-                    padding: const EdgeInsets.all(3.0),
-                    child: Text(
-                      item.title,
-                      style: Styles.textBody,
-                    ),
+        ),
+        Expanded(
+          flex: 90,
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(12, 2, 2, 2),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.start,
+              mainAxisSize: MainAxisSize.max,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.all(3.0),
+                  child: Text(
+                    item.title,
+                    style: Styles.textBody,
                   ),
-                  if (item.subtitle != null)
-                    Padding(
-                      padding: const EdgeInsets.all(2.0),
-                      child: Text(
-                        item.subtitle,
-                        style: Styles.textFooter,
-                      ),
-                    )
-                ],
-              ),
+                ),
+                if (item.subtitle != null)
+                  Padding(
+                    padding: const EdgeInsets.all(2.0),
+                    child: Text(
+                      item.subtitle,
+                      style: Styles.textFooter,
+                    ),
+                  )
+              ],
             ),
-          )
-        ],
-      );
+          ),
+        )
+      ],
+    );
   }
 
   Widget _renderSubsection(ICUDailyRoundStepSubsection subsection) {

--- a/lib/widget/lists/icu_daily_round_steps_card.dart
+++ b/lib/widget/lists/icu_daily_round_steps_card.dart
@@ -10,9 +10,7 @@ class ICUDailyRoundStepsCard extends StatelessWidget {
   const ICUDailyRoundStepsCard({this.section});
 
   Widget _renderItems(ICUDailyRoundItem item) {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(0, 0, 0, 16),
-      child: Row(
+    return Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
           Expanded(
@@ -60,8 +58,7 @@ class ICUDailyRoundStepsCard extends StatelessWidget {
             ),
           )
         ],
-      ),
-    );
+      );
   }
 
   Widget _renderSubsection(ICUDailyRoundStepSubsection subsection) {
@@ -87,7 +84,12 @@ class ICUDailyRoundStepsCard extends StatelessWidget {
         elevation: 0,
         child: <Widget>[
           _renderHeading(),
-          ...subsection.list.map((item) => _renderItems(item)).toList(),
+          Wrap(
+            runSpacing: 16.0,
+            direction: Axis.horizontal,
+            children:
+                subsection.list.map((item) => _renderItems(item)).toList(),
+          ),
           _renderFooter()
         ]);
   }


### PR DESCRIPTION
Resolved #322

## Abstract
This PR will fix the too large bottom margins for the cards in ICU cells (and the pages that use the same template).

## Changes

- Remove the bottom padding of each card
- Add spacing between cards

## Screenshots
![Simulator Screen Shot - iPhone 11 Pro - 2020-05-06 at 22 43 46](https://user-images.githubusercontent.com/14011195/81178532-afef3f00-8feb-11ea-9865-36357d505ca7.png)

## Things to note
Would be great if you know any other good ways to add spacing between elements. Using `Wrap` is bit hacky.