### PR TITLE
Add place holder for last updated time

### DIFF
--- a/lib/env.dart
+++ b/lib/env.dart
@@ -1,3 +1,6 @@
 /// NOTE: this file will be OVER-WRITTEN at build time with values
 /// from environment variables on the build/CI server
 const dsn = 'PROVIDED_AT_BUILD_TIME';
+// Last updated date is used in disclaimer page and CI updates it automatically
+// Leave this string empty before CI updates it
+const lastUpdatedTime = '';

--- a/lib/view/info_view.dart
+++ b/lib/view/info_view.dart
@@ -83,7 +83,6 @@ class InfoView extends StatelessWidget {
   static Widget _buildSpacer({double height = 16}) => Container(height: height);
 
   Widget _buildLastUpdatedDate() {
-
     String formatTimestamp(int timestamp) {
       final format = DateFormat('h:mma dd MMMM yyyy');
       final date = DateTime.fromMillisecondsSinceEpoch(timestamp * 1000);

--- a/lib/view/info_view.dart
+++ b/lib/view/info_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'package:package_info/package_info.dart';
 
 import '../env.dart';
@@ -82,13 +83,22 @@ class InfoView extends StatelessWidget {
   static Widget _buildSpacer({double height = 16}) => Container(height: height);
 
   Widget _buildLastUpdatedDate() {
-    if (lastUpdatedTime.isEmpty) {
+
+    String formatTimestamp(int timestamp) {
+      final format = DateFormat('h:mma dd MMMM yyyy');
+      final date = DateTime.fromMillisecondsSinceEpoch(timestamp * 1000);
+      return format.format(date);
+    }
+
+    final timestamp = int.tryParse(lastUpdatedTime);
+
+    if (timestamp == null) {
       return Container();
     } else {
       return Container(
         margin: const EdgeInsets.all(8.0),
         child: Text(
-          'Last updated $lastUpdatedTime',
+          'Last updated ${formatTimestamp(timestamp)}',
           textAlign: TextAlign.center,
           style: Styles.textFooter,
         ),

--- a/lib/view/info_view.dart
+++ b/lib/view/info_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:package_info/package_info.dart';
 
+import '../env.dart';
 import '../hard_data.dart';
 import '../routes.dart';
 import '../strings.dart';
@@ -80,6 +81,21 @@ class InfoView extends StatelessWidget {
 
   static Widget _buildSpacer({double height = 16}) => Container(height: height);
 
+  Widget _buildLastUpdatedDate() {
+    if (lastUpdatedTime.isEmpty) {
+      return Container();
+    } else {
+      return Container(
+        margin: const EdgeInsets.all(8.0),
+        child: Text(
+          'Last updated $lastUpdatedTime',
+          textAlign: TextAlign.center,
+          style: Styles.textFooter,
+        ),
+      );
+    }
+  }
+
   List<Widget> _buildAbout() {
     return [
       Center(
@@ -99,6 +115,7 @@ class InfoView extends StatelessWidget {
       _buildSpacer(height: 8),
       Center(child: _buildVersionTextWidget()),
       _buildSpacer(height: 8),
+      _buildLastUpdatedDate(),
       const Padding(
         padding: EdgeInsets.all(8.0),
         child: Text(


### PR DESCRIPTION
Resolved #288

## Abstract
This PR will add a placeholder for the last updated time in env.dart. Then CI should update this variable in a format of `10:17pm 07 May 2020`

## Changes

- Add last updated date placeholder
- Display last updated date if there's any in the info view

## Screenshots
![Screenshot_1588854003](https://user-images.githubusercontent.com/14011195/81294466-4a19ba80-90b2-11ea-9a75-34d36479c161.png)

## Things to note
If CI has not added the last updated time, then CI might overwrite `env.dart` and variable `lastUpdatedTime` will disappear. And it could result in build failure. @maks 