### PR TITLE
Updates for Flutter Stable v1.17.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:3.5.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.google.gms:google-services:4.3.3'
     }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -212,7 +212,7 @@ SPEC CHECKSUMS:
   GoogleDataTransportCCTSupport: d70a561f7d236af529fee598835caad5e25f6d3d
   GoogleUtilities: 39530bc0ad980530298e9c4af8549e991fd033b1
   nanopb: c43f40fadfe79e8b8db116583945847910cbabc9
-  native_pdf_renderer: f84efbd910ee6a9ee679f4228ce704a14ef90a38
+  native_pdf_renderer: fa374da660730abe059e7a178e79895dd202f007
   package_info: 873975fc26034f0b863a300ad47e7f1ac6c7ec62
   path_provider: abfe2b5c733d04e238b0d8691db0cfd63a27a93c
   path_provider_macos: f760a3c5b04357c380e2fddb6f9db6f3015897e0

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,6 +24,7 @@ void main() {
     };
   }
 
+  // TODO - runZoned is deprecated, ignoring for now until Sentry setup is clear
   // This creates a [Zone] that contains the Flutter application and establishes
   // an error handler that captures errors.
   //
@@ -43,6 +44,7 @@ void main() {
         child: const WHApp(),
       ),
     );
+    // ignore: deprecated_member_use
   }, onError: (Object error, StackTrace stackTrace) {
     // Whenever an error occurs, call the `reportError` function. This sends
     // Dart errors to the dev console or Sentry depending on the environment.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -25,6 +25,9 @@ void main() {
   }
 
   // TODO - runZoned is deprecated, ignoring for now until Sentry setup is clear
+  // with runZonedGuarded as per https://github.com/dart-lang/sdk/issues/40681
+  // and https://github.com/flutter/flutter/issues/53185
+  //
   // This creates a [Zone] that contains the Flutter application and establishes
   // an error handler that captures errors.
   //

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,28 +7,28 @@ packages:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.11"
+    version: "2.0.13"
   args:
     dependency: transitive
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.2"
+    version: "1.6.0"
   async:
     dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.1"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "2.0.0"
   cached_network_image:
     dependency: transitive
     description:
@@ -42,7 +42,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.3"
   chewie:
     dependency: "direct main"
     description:
@@ -63,7 +63,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.11"
+    version: "1.14.12"
   convert:
     dependency: transitive
     description:
@@ -77,7 +77,7 @@ packages:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.4"
   csslib:
     dependency: transitive
     description:
@@ -93,26 +93,26 @@ packages:
     source: hosted
     version: "0.4.2+4"
   extended_image:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: extended_image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.3+1"
   extended_image_library:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: extended_image_library
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.1"
+    version: "0.2.3"
   extension:
     dependency: transitive
     description:
       name: extension
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.5"
+    version: "0.1.1"
   file:
     dependency: transitive
     description:
@@ -232,7 +232,7 @@ packages:
       name: image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.12"
   intl:
     dependency: "direct main"
     description:
@@ -274,14 +274,14 @@ packages:
       name: native_pdf_renderer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.3.0"
   native_pdf_view:
     dependency: "direct main"
     description:
       name: native_pdf_view
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.0"
+    version: "3.4.0"
   nested:
     dependency: transitive
     description:
@@ -386,14 +386,14 @@ packages:
       name: provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.5+1"
+    version: "4.1.2"
   quiver:
     dependency: transitive
     description:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.5"
+    version: "2.1.3"
   rxdart:
     dependency: transitive
     description:
@@ -447,7 +447,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.5"
+    version: "1.7.0"
   sqflite:
     dependency: transitive
     description:
@@ -601,7 +601,7 @@ packages:
       name: xml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.5.0"
+    version: "3.6.1"
 sdks:
-  dart: ">=2.8.0-dev <3.0.0"
-  flutter: ">=1.15.17 <2.0.0"
+  dart: ">=2.8.2 <3.0.0"
+  flutter: ">=1.17.1 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,32 +4,28 @@ description: A new Flutter project.
 version: 1.0.0+1
 
 environment:
-  sdk: ^2.8.0-dev
-  flutter: ^1.15.17
+  sdk: ^2.8.2
+  flutter: ^1.17.1
 
 dependencies:
   flutter:
     sdk: flutter
-  package_info: ^0.4.0+16
+  package_info: ^0.4.0+18
   chewie: ^0.9.10
-  video_player: ^0.10.8+1
-  flutter_widget_from_html: ^0.3.2+2
+  video_player: ^0.10.11
+  flutter_widget_from_html: ^0.3.3+3
   matrix_gesture_detector: ^0.1.0
-  url_launcher: ^5.4.2
-  flutter_svg: ^0.17.3+1
-  shared_preferences: ^0.5.6+3
-  intl: ^0.16.0
+  url_launcher: ^5.4.7
+  flutter_svg: ^0.17.4
+  shared_preferences: ^0.5.7+2
+  intl: ^0.16.1
   photo_view: ^0.9.2
-  provider: ^4.0.4
+  provider: ^4.1.2
   firebase_core: ^0.4.4+3
   firebase_analytics: ^5.0.11
   sentry: ^3.0.1
-  device_info: ^0.4.2+1
-#  Temporary fix for extended_image and extended_image_library
-#  as per this issue: https://github.com/fluttercandies/extended_image/issues/160
-  extended_image: 0.7.2
-  extended_image_library: 0.2.1
-  native_pdf_view: ^3.1.0
+  device_info: ^0.4.2+4
+  native_pdf_view: ^3.4.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A new Flutter project.
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.8.0-dev.12.0 <3.0.0'
+  sdk: '>=2.8.2 <3.0.0'
   flutter: ^1.17.1
 
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: A new Flutter project.
 version: 1.0.0+1
 
 environment:
-  sdk: ^2.8.2
+  sdk: '>=2.8.0-dev.12.0 <3.0.0'
   flutter: ^1.17.1
 
 dependencies:

--- a/release_notes.txt
+++ b/release_notes.txt
@@ -1,6 +1,6 @@
 ---- Monday 18th May, 2020 ----
 * Updated Flutter framework to latest stable
-* Updated several packages and build setups to versions with fixes
+* Updated several packages and build setups to versions with fixes 
 
 ---- Sunday 17th May, 2020 ----
 * Added Onboarding screens for key content at app startup

--- a/release_notes.txt
+++ b/release_notes.txt
@@ -1,6 +1,7 @@
 ---- Monday 18th May, 2020 ----
 * Updated Flutter framework to latest stable
-* Updated several packages and build setups to versions with fixes 
+* Updated several packages with fixes
+* Build pipeline updated for new configuration
 
 ---- Sunday 17th May, 2020 ----
 * Added Onboarding screens for key content at app startup

--- a/release_notes.txt
+++ b/release_notes.txt
@@ -1,3 +1,7 @@
+---- Monday 18th May, 2020 ----
+* Updated Flutter framework to latest stable
+* Updated several packages and build setups to versions with fixes
+
 ---- Sunday 17th May, 2020 ----
 * Added Onboarding screens for key content at app startup
 * Updated Disclaimer to remove content moved to Onboarding screens


### PR DESCRIPTION
Updated the project, packages and build system for Flutter stable channel v1.17.1. 

We have accumulated quite a few issues on the project now, due to being on the older v1.15.17 version of flutter. Now that v1.17.x is a few weeks mature and the major have thumbs upped the move, time to update the project for v1.17.1 and get back to the stable branch of flutter. This should ensure good package and dependency support and maintainability for the project going forward.

## Changes

- [x] Upgraded to run with Flutter v1.17.1
- [x] Upgraded gradle and wrapper to AS standard set of v3.5.3 and v5.4.1
- [x] Numerous package upgrades where fixes present
- [x] Reverted regressed tnative_pdf_view package to the latest now issues resolved
- [x] Sentry left as is and lint warning ignored, due to it currently being unclear of impact of runZoned being deprecated in favour of runZonedGuarded in v1.17.x of Flutter
- [x] codemagic CI updated to use flutter v1.17.1

## Things to note

- Flutter v1.17.1 and Dart v2.8.2 now required in `pubspec.yaml`
- Re-tested all features on several iOS and Android devices
- Several console warnings and message now gone as a result of the upgrade
- Performance increased on iOS