### PR TITLE
Update readme with warning project is not maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,6 @@ This project is licensed under the Apache 2.0 - see the `LICENSE-2.0.txt` file f
 
 Western Health logos belong solely to Western Health may be subject to their copyrights and trademarks, and are not available under the same license as the rest of this application.
 
-
-## Emergency contacts
-
-For any urgent requests relating to this app you can contact luke.sleeman@gmail.com - It will go to Luke's phone.  You can also DM Luke through [GDG Melbourne's slack](http://bit.ly/join_gdgslack) - DM `@luke.sleeman`.
-
 ## Acknowledgements
 
 So many people have worked together to make this project happen, and helped out in so many ways 🥰

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+**🚨🚨🚨 The WHAC19 project is no longer being developed & maintained.  🚨🚨🚨** 
+
+We are incredibly grateful to all our [contributors](#Contributors) - we did great things together
+during the most difficult of times ❤️
+
+Thank-you everybody for the huge amounts of effort which was contributed to this project.
+
+This projects open issues, branches and PR's have been cleaned out and put in a state which gives 
+an accurate snapshot of the project.  We are not soliciting pull requests or other contributions.  
+The project is in a state where it could be picked up and used as a 
+basis for other hospital informational apps.  Please make sure you check through the list of
+open [issues](https://github.com/Western-Health-Covid19-Collaboration/wh_covid19_app/issues) before beginning any work.
+
 # WHAC19 - Western Health Anaesthesia Covid-19
 
 The WHAC19 app is a tool to safeguard the welfare of Western Health anaesthetists during COVID-19 and provide instant access to the most up-to-date information for time-critical procedures to ensure optimal patient care.  This app will contain information for frontline medical staff on subjects such as:


### PR DESCRIPTION
## Changes

This PR updates the readme with a warning that the project is no longer maintained. 

It also removes the emergency contact section of the readme


## Screenshots

![image](https://user-images.githubusercontent.com/902252/91651969-2bfb1e80-ead6-11ea-915f-8f4bc394f5ab.png)


## Things to note

I'm happy to take suggestions from anybody on the project on this PR